### PR TITLE
fix docker tsconfig paths and gateway types

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -16,11 +16,15 @@ services:
     ports:
       - "8000:8000"
   kitchen-panel:
-    build: ../packages/kitchen-panel
+    build:
+      context: ..
+      dockerfile: packages/kitchen-panel/Dockerfile
     ports:
       - "8080:80"
   gateway:
-    build: ../packages/gateway
+    build:
+      context: ..
+      dockerfile: packages/gateway/Dockerfile
     ports:
       - "3000:3000"
     depends_on:

--- a/packages/gateway/Dockerfile
+++ b/packages/gateway/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:22-alpine
 WORKDIR /app
-COPY package.json tsconfig.json ./
-COPY src ./src
+
+# Copy package-specific files
+COPY packages/gateway/package.json packages/gateway/tsconfig.json ./
+# Copy shared base TypeScript config
+COPY tsconfig.json /tsconfig.json
+
+COPY packages/gateway/src ./src
 RUN npm install && npm run build
 CMD ["node", "dist/index.js"]

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -13,6 +13,8 @@
     "socket.io": "^4.7.2"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.30",
     "typescript": "^5.4.0"
   }
 }

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 
@@ -8,9 +8,9 @@ const io = new Server(httpServer, { cors: { origin: '*' } });
 
 app.use(express.json());
 
-app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+app.get('/health', (_req: Request, res: Response) => res.json({ status: 'ok' }));
 
-app.post('/orders', (req, res) => {
+app.post('/orders', (req: Request, res: Response) => {
   io.emit('order:new', req.body.order || 'unknown');
   res.sendStatus(200);
 });

--- a/packages/kitchen-panel/Dockerfile
+++ b/packages/kitchen-panel/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:22-alpine as build
 WORKDIR /app
-COPY package.json tsconfig.json vite.config.ts index.html ./
-COPY src ./src
+
+# Copy package-specific files
+COPY packages/kitchen-panel/package.json packages/kitchen-panel/tsconfig.json packages/kitchen-panel/vite.config.ts packages/kitchen-panel/index.html ./
+# Copy shared base TypeScript config
+COPY tsconfig.json /tsconfig.json
+
+COPY packages/kitchen-panel/src ./src
 RUN npm install && npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
## Summary
- include base tsconfig in gateway and kitchen-panel images
- adjust docker compose contexts for frontend and gateway builds
- add missing express typings and parameter types in gateway

## Testing
- `npm --prefix packages/gateway install && npm --prefix packages/gateway run build`
- `npm --prefix packages/kitchen-panel install && npm --prefix packages/kitchen-panel run build`


------
https://chatgpt.com/codex/tasks/task_e_688e4f48f1dc832eadc90db974bedbb7